### PR TITLE
Add macOS universal PKG build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,10 +308,54 @@ jobs:
           path: msi-output/
           retention-days: 7
 
+  build-macos-pkg:
+    name: Build macOS PKG
+    runs-on: macos-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Download darwin binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/darwin
+
+      - name: Prepare universal binary
+        run: |
+          mkdir -p pkg-root/usr/local/bin
+          cp dist/darwin/binaries-darwin-amd64/fetch-k8s-cert-darwin-amd64 pkg-root/usr/local/bin/fetch-k8s-cert-amd64
+          cp dist/darwin/binaries-darwin-arm64/fetch-k8s-cert-darwin-arm64 pkg-root/usr/local/bin/fetch-k8s-cert-arm64
+          lipo -create -output pkg-root/usr/local/bin/fetch-k8s-cert \
+            pkg-root/usr/local/bin/fetch-k8s-cert-amd64 \
+            pkg-root/usr/local/bin/fetch-k8s-cert-arm64
+          chmod 755 pkg-root/usr/local/bin/fetch-k8s-cert
+          rm pkg-root/usr/local/bin/fetch-k8s-cert-amd64 pkg-root/usr/local/bin/fetch-k8s-cert-arm64
+
+      - name: Build PKG
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          mkdir -p pkg-output
+          pkgbuild \
+            --root pkg-root \
+            --identifier com.rossigee.fetch-k8s-cert \
+            --version "$VERSION" \
+            --install-location / \
+            pkg-output/fetch-k8s-cert-${VERSION}-universal.pkg
+
+      - name: Upload PKG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-macos-universal
+          path: pkg-output/
+          retention-days: 7
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build, build-windows-msi]
+    needs: [build, build-windows-msi, build-macos-pkg]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Check out code


### PR DESCRIPTION
Adds a universal macOS .pkg installer (amd64+arm64) built via `pkgbuild` on macos-latest.